### PR TITLE
MOSU-9 feat: 로그 수집 및 시스템 모니터링 구성 및 docker-compose 환경 분리

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,49 +1,34 @@
-# 기본 변수 정의
-COMPOSE = docker-compose
-DOCKER = docker
-PROJECT_NAME = mosu
+.PHONY: prod-up prod-down local-up local-down
 
-# 환경별 공통 옵션
-LOCAL_COMPOSE_FILE = docker-compose/docker-compose.local.yml
-LOCAL_ENV_FILE = docker-compose/.env.local
+# Target for bringing up the production environment
+prod-up:
+	@echo "Bringing up production environment..."
+	docker compose -f docker-compose/docker-compose.prod.yml --env-file docker-compose/.env.prod up -d --build
+	@echo "Production environment is up!"
 
-PROD_COMPOSE_FILE = docker-compose/docker-compose.prod.yml
-PROD_ENV_FILE = docker-compose/.env.prod
+# Target for bringing down the production environment
+prod-down:
+	@echo "Bringing down production environment..."
+	docker compose -f docker-compose/docker-compose.prod.yml --env-file docker-compose/.env.prod down
+	@echo "Production environment is down!"
 
-# 공통 실행 함수
-define compose_up
-	$(COMPOSE) -p $(PROJECT_NAME) -f $(1) --env-file $(2) up -d
-endef
+# Target for bringing up the local development environment
+# Assumes docker-compose/docker-compose.local.yml and docker-compose/.env.local exist
+local-up:
+	@echo "Bringing up local development environment..."
+	docker compose -f docker-compose/docker-compose.local.yml --env-file docker-compose/.env.local up -d --build
+	@echo "Local development environment is up!"
 
-define compose_down
-	$(COMPOSE) -p $(PROJECT_NAME) down
-endef
+# Target for bringing down the local development environment
+local-down:
+	@echo "Bringing down local development environment..."
+	docker compose -f docker-compose/docker-compose.local.yml --env-file docker-compose/.env.local down
+	@echo "Local development environment is down!"
 
-define compose_ps
-	$(COMPOSE) -p $(PROJECT_NAME) ps
-endef
-
-# 실행 (로컬)
-up-local:
-	$(call compose_up, $(LOCAL_COMPOSE_FILE), $(LOCAL_ENV_FILE))
-
-# 실행 (운영)
-up-prod:
-	$(call compose_up, $(PROD_COMPOSE_FILE), $(PROD_ENV_FILE))
-
-# 중지 및 컨테이너 제거
-down:
-	$(call compose_down)
-
-# 상태 보기
-ps:
-	$(call compose_ps)
-
-# 재시작
-restart-local:
-	$(call compose_down)
-	$(call compose_up, $(LOCAL_COMPOSE_FILE), $(LOCAL_ENV_FILE))
-
-restart-prod:
-	$(call compose_down)
-	$(call compose_up, $(PROD_COMPOSE_FILE), $(PROD_ENV_FILE))
+# Default target - shows available commands
+help:
+	@echo "Usage:"
+	@echo "  make prod-up    - Build and start production services"
+	@echo "  make prod-down  - Stop and remove production services"
+	@echo "  make local-up   - Build and start local development services"
+	@echo "  make local-down - Stop and remove local development services"

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,49 @@
+# 기본 변수 정의
+COMPOSE = docker-compose
+DOCKER = docker
+PROJECT_NAME = mosu
+
+# 환경별 공통 옵션
+LOCAL_COMPOSE_FILE = docker-compose/docker-compose.local.yml
+LOCAL_ENV_FILE = docker-compose/.env.local
+
+PROD_COMPOSE_FILE = docker-compose/docker-compose.prod.yml
+PROD_ENV_FILE = docker-compose/.env.prod
+
+# 공통 실행 함수
+define compose_up
+	$(COMPOSE) -p $(PROJECT_NAME) -f $(1) --env-file $(2) up -d
+endef
+
+define compose_down
+	$(COMPOSE) -p $(PROJECT_NAME) down
+endef
+
+define compose_ps
+	$(COMPOSE) -p $(PROJECT_NAME) ps
+endef
+
+# 실행 (로컬)
+up-local:
+	$(call compose_up, $(LOCAL_COMPOSE_FILE), $(LOCAL_ENV_FILE))
+
+# 실행 (운영)
+up-prod:
+	$(call compose_up, $(PROD_COMPOSE_FILE), $(PROD_ENV_FILE))
+
+# 중지 및 컨테이너 제거
+down:
+	$(call compose_down)
+
+# 상태 보기
+ps:
+	$(call compose_ps)
+
+# 재시작
+restart-local:
+	$(call compose_down)
+	$(call compose_up, $(LOCAL_COMPOSE_FILE), $(LOCAL_ENV_FILE))
+
+restart-prod:
+	$(call compose_down)
+	$(call compose_up, $(PROD_COMPOSE_FILE), $(PROD_ENV_FILE))

--- a/Makefile
+++ b/Makefile
@@ -1,34 +1,34 @@
 .PHONY: prod-up prod-down local-up local-down
 
-# Target for bringing up the production environment
+# 프로덕션 환경을 실행하는 명령어
 prod-up:
-	@echo "Bringing up production environment..."
+	@echo "프로덕션 환경을 실행 중..."
 	docker compose -f docker-compose/docker-compose.prod.yml --env-file docker-compose/.env.prod up -d --build
-	@echo "Production environment is up!"
+	@echo "프로덕션 환경이 실행되었습니다!"
 
-# Target for bringing down the production environment
+# 프로덕션 환경을 중지하는 명령어
 prod-down:
-	@echo "Bringing down production environment..."
+	@echo "프로덕션 환경을 중지 중..."
 	docker compose -f docker-compose/docker-compose.prod.yml --env-file docker-compose/.env.prod down
-	@echo "Production environment is down!"
+	@echo "프로덕션 환경이 중지되었습니다!"
 
-# Target for bringing up the local development environment
-# Assumes docker-compose/docker-compose.local.yml and docker-compose/.env.local exist
+# 로컬 개발 환경을 실행하는 명령어
+# docker-compose/docker-compose.local.yml 및 docker-compose/.env.local 파일이 존재해야 함
 local-up:
-	@echo "Bringing up local development environment..."
+	@echo "로컬 개발 환경을 실행 중..."
 	docker compose -f docker-compose/docker-compose.local.yml --env-file docker-compose/.env.local up -d --build
-	@echo "Local development environment is up!"
+	@echo "로컬 개발 환경이 실행되었습니다!"
 
-# Target for bringing down the local development environment
+# 로컬 개발 환경을 중지하는 명령어
 local-down:
-	@echo "Bringing down local development environment..."
+	@echo "로컬 개발 환경을 중지 중..."
 	docker compose -f docker-compose/docker-compose.local.yml --env-file docker-compose/.env.local down
-	@echo "Local development environment is down!"
+	@echo "로컬 개발 환경이 중지되었습니다!"
 
-# Default target - shows available commands
+# 기본 명령어 - 사용 가능한 명령어 출력
 help:
-	@echo "Usage:"
-	@echo "  make prod-up    - Build and start production services"
-	@echo "  make prod-down  - Stop and remove production services"
-	@echo "  make local-up   - Build and start local development services"
-	@echo "  make local-down - Stop and remove local development services"
+	@echo "사용법:"
+	@echo "  make prod-up    - 프로덕션 서비스 빌드 및 실행"
+	@echo "  make prod-down  - 프로덕션 서비스 중지 및 제거"
+	@echo "  make local-up   - 로컬 개발 서비스 빌드 및 실행"
+	@echo "  make local-down - 로컬 개발 서비스 중지 및 제거"

--- a/build.gradle
+++ b/build.gradle
@@ -49,6 +49,9 @@ dependencies {
     implementation 'software.amazon.awssdk:core:2.30.20'
     implementation 'software.amazon.awssdk:ec2'
 
+    //monitoring
+    implementation 'org.springframework.boot:spring-boot-starter-actuator'
+    implementation 'io.micrometer:micrometer-registry-prometheus'
 }
 
 tasks.named('test') {

--- a/docker-compose/docker-compose.local.yml
+++ b/docker-compose/docker-compose.local.yml
@@ -1,7 +1,7 @@
 services:
   app:
     build:
-      context: .
+      context: ..
       dockerfile: Dockerfile
     container_name: mosu-server
     env_file:
@@ -11,6 +11,8 @@ services:
     ports:
       - ${SPRING_PORT}:${SPRING_PORT}
     restart: always
+    networks:
+      - mosu-bridge
 
   database:
     image: mysql:8.4.4
@@ -29,6 +31,12 @@ services:
     restart: no
     volumes:
       - mosu-database:/var/lib/mysql
+    networks:
+      - mosu-bridge
 
 volumes:
   mosu-database:
+
+networks:
+  mosu-bridge:
+    driver: bridge

--- a/docker-compose/docker-compose.prod.yml
+++ b/docker-compose/docker-compose.prod.yml
@@ -8,6 +8,7 @@ services:
       - ${ENV_FILE}
     depends_on:
       - database
+      - prometheus
     ports:
       - ${SPRING_PORT}:${SPRING_PORT}
     restart: always
@@ -33,6 +34,7 @@ services:
       - mosu-database:/var/lib/mysql
     networks:
       - mosu-bridge
+
   velkey:
     image: ghcr.io/valkey-io/valkey:7.2
     container_name: mosu-velkey

--- a/docker-compose/docker-compose.prod.yml
+++ b/docker-compose/docker-compose.prod.yml
@@ -1,0 +1,82 @@
+services:
+  app:
+    build:
+      context: ..
+      dockerfile: Dockerfile
+    container_name: mosu-server
+    env_file:
+      - ${ENV_FILE}
+    depends_on:
+      - database
+    ports:
+      - ${SPRING_PORT}:${SPRING_PORT}
+    restart: always
+    networks:
+      - mosu-bridge
+
+  database:
+    image: mysql:8.4.4
+    container_name: mosu-database
+    environment:
+      MYSQL_ROOT_PASSWORD: ${DB_PASSWORD}
+      MYSQL_DATABASE: ${DB_DATABASE}
+      MYSQL_USER: ${DB_USERNAME}
+      MYSQL_PASSWORD: ${DB_PASSWORD}
+    command:
+      --port=${DB_PORT} --max_allowed_packet=32M
+    expose:
+      - ${DB_PORT}
+    ports:
+      - ${DB_PORT}:${DB_PORT}
+    restart: no
+    volumes:
+      - mosu-database:/var/lib/mysql
+    networks:
+      - mosu-bridge
+  velkey:
+    image: ghcr.io/valkey-io/valkey:7.2
+    container_name: mosu-velkey
+    command: [ "valkey-server", "--port", "${VELKEY_PORT}" ]
+    ports:
+      - ${VELKEY_PORT}:${VELKEY_PORT}
+    networks:
+      - mosu-bridge
+
+  redis-exporter:
+    image: oliver006/redis_exporter:v1.58.0
+    container_name: mosu-redis-exporter
+    environment:
+      REDIS_ADDR: redis://velkey:${VELKEY_PORT}
+    ports:
+      - ${REDIS_EXPORTER}:${REDIS_EXPORTER}
+    depends_on:
+      - velkey
+    networks:
+      - mosu-bridge
+
+  prometheus:
+    image: prom/prometheus:latest
+    container_name: mosu-prometheus
+    ports:
+      - ${PROMETHEUS_PORT}:${PROMETHEUS_PORT}
+    volumes:
+      - ./prometheus/config.yml:/etc/prometheus/prometheus.yml
+    networks:
+      - mosu-bridge
+
+  grafana:
+    image: grafana/grafana:latest
+    container_name: mosu-grafana
+    ports:
+      - ${GRAFANA_PORT}:${GRAFANA_PORT}
+    depends_on:
+      - prometheus
+    networks:
+      - mosu-bridge
+
+volumes:
+  mosu-database:
+
+networks:
+  mosu-bridge:
+    driver: bridge

--- a/docker-compose/docker-compose.prod.yml
+++ b/docker-compose/docker-compose.prod.yml
@@ -6,6 +6,8 @@ services:
     container_name: mosu-server
     env_file:
       - ${ENV_FILE}
+    volumes:
+      - ./logs:/logs
     depends_on:
       - database
       - prometheus
@@ -73,6 +75,30 @@ services:
       - ${GRAFANA_PORT}:${GRAFANA_PORT}
     depends_on:
       - prometheus
+    networks:
+      - mosu-bridge
+
+  promtail:
+    image: grafana/promtail:latest
+    container_name: promtail
+    volumes:
+      - ./promtail/config.yml:/etc/promtail/config.yml
+      - ./logs:/var/log/spring-app
+    command:
+      - -config.file=/etc/promtail/config.yml
+      - -config.expand-env=true
+    depends_on:
+      - loki
+    networks:
+      - mosu-bridge
+
+  loki:
+    image: grafana/loki:latest
+    container_name: loki
+    ports:
+      - ${LOKI_PORT}:${LOKI_PORT}
+    volumes:
+      - ./loki/data:/var/lib/loki
     networks:
       - mosu-bridge
 

--- a/docker-compose/docker-compose.prod.yml
+++ b/docker-compose/docker-compose.prod.yml
@@ -73,6 +73,8 @@ services:
     container_name: mosu-grafana
     ports:
       - ${GRAFANA_PORT}:${GRAFANA_PORT}
+    volumes:
+      - ./grafana/data:/var/lib/grafana
     depends_on:
       - prometheus
     networks:

--- a/docker-compose/prometheus/config.yml
+++ b/docker-compose/prometheus/config.yml
@@ -1,0 +1,20 @@
+global:
+  scrape_interval: 15s
+
+scrape_configs:
+  - job_name: 'prometheus'
+    metrics_path: '/actuator/prometheus'
+    static_configs:
+      - targets: ['mosu-server:8080']
+
+  - job_name: 'mysql'
+    static_configs:
+      - targets: ['mosu-database:9104']
+
+  - job_name: 'redis'
+    static_configs:
+      - targets: ["mosu-redis-exporter:9121"]
+
+  - job_name: 'prometheus-self'
+    static_configs:
+      - targets: ['mosu-prometheus:9090']

--- a/docker-compose/prometheus/config.yml
+++ b/docker-compose/prometheus/config.yml
@@ -3,9 +3,9 @@ global:
 
 scrape_configs:
   - job_name: 'prometheus'
-    metrics_path: '/actuator/prometheus'
+    metrics_path: '/api/v1/actuator/prometheus'
     static_configs:
-      - targets: ['mosu-server:8080']
+      - targets: ['mosu-server:20000']
 
   - job_name: 'mysql'
     static_configs:

--- a/docker-compose/promtail/config.yml
+++ b/docker-compose/promtail/config.yml
@@ -1,0 +1,15 @@
+server:
+  http_listen_port: 9080
+  grpc_listen_port: 0
+
+clients:
+  - url: http://loki:3100/loki/api/v1/push
+
+scrape_configs:
+  - job_name: mosu-server-log
+    static_configs:
+      - targets:
+          - localhost
+        labels:
+          job: mosu-server
+          __path__: /var/log/spring-app/*.log

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -40,6 +40,12 @@ springdoc:
   swagger-ui:
     path: /swagger
 
+management:
+  endpoints:
+    web:
+      exposure:
+        include: "*"
+
 aws:
   s3:
     bucket-name: ${AWS_BUCKET_NAME}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -53,3 +53,8 @@ aws:
     access-key: ${AWS_ACCESS_KEY}
     secret-key: ${AWS_SECRET_KEY}
     presigned-url-expiration-minutes: ${S3_PRESIGNED_URL_EXPIRATION_MINUTES}
+
+logging:
+  file:
+    path: ./logs
+    name: app.log

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+
+  <property name="LOG_PATH" value="./logs"/>
+  <property name="LOG_FILE" value="${LOG_PATH}/app.log"/>
+
+  <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+    <encoder>
+      <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} %-5level %logger{36} - %msg%n</pattern>
+      <charset>UTF-8</charset>
+    </encoder>
+  </appender>
+
+  <appender name="FILE" class="ch.qos.logback.core.FileAppender">
+    <file>${LOG_FILE}</file>
+    <encoder>
+      <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} %-5level %logger{36} - %msg%n</pattern>
+      <charset>UTF-8</charset>
+    </encoder>
+  </appender>
+
+  <root level="INFO">
+    <appender-ref ref="CONSOLE"/>
+    <appender-ref ref="FILE"/>
+  </root>
+
+</configuration>


### PR DESCRIPTION
## 😎 연결된 이슈
- close#9 
## ✨ 구현한 기능
- docker-compose 파일 local, prod 환경에 맞게 분리
- Makefile 을 통해 커스텀 커맨드로 빠른 docker 데몬 실행
- prometheus scrape 설정을 통해 redis, application 모니터링
- docker-compose 스크립트 내에 network 를 명시적으로 넣어서 관리하는게 안정성이 좋기 때문에 이 부분을 추가하고
- docker-compose 스크립트 내에 depend on 으로 상호 관계를 주입했습니다.
- promtail 을 통해 log 데이터를 지속적으로 loki 에 보낼 수 있도록 처리
- loki 로 보낸 데이터를 grafana 로 부터 커스텀 대시보드 구현

## 📢 논의하고 싶은 내용
- velkey 를 달긴 했는데 추후, 크기나 가용량에 대한 최적화 필요
- actuator 에 대한 접근을 어떤식으로 제한할 것인지에 대해서 고려해야함

## 🎸 스크린샷
### Redis
![image](https://github.com/user-attachments/assets/f695728d-9d1d-41fe-97e7-cd226d98faba)
### Application
![image](https://github.com/user-attachments/assets/bd4da5c6-8ee5-4d40-942f-72b339893b8c)
### Log 
![image](https://github.com/user-attachments/assets/c6ff6058-ab7f-4970-927c-beae37e6f84c)

## 커맨드 내용

| 명령어               | 설명                             |
| ----------------- | ------------------------------ |
| `make prod-up`    | 프로덕션 환경을 빌드하고 컨테이너를 백그라운드로 실행  |
| `make prod-down`  | 프로덕션 환경 컨테이너를 중지하고 제거          |
| `make local-up`   | 로컬 개발 환경을 빌드하고 컨테이너를 백그라운드로 실행 |
| `make local-down` | 로컬 개발 환경 컨테이너를 중지하고 제거         |
| `make help`       | 사용 가능한 명령어들을 출력                |
