### PR TITLE
MOSU-21 refactor: 파일 업로드 기능과 FAQ 기능을 분리 

### DIFF
--- a/src/main/java/life/mosu/mosuserver/application/faq/FaqService.java
+++ b/src/main/java/life/mosu/mosuserver/application/faq/FaqService.java
@@ -10,10 +10,14 @@ import life.mosu.mosuserver.domain.faq.FaqJpaEntity;
 import life.mosu.mosuserver.domain.faq.FaqRepository;
 import life.mosu.mosuserver.global.exception.CustomRuntimeException;
 import life.mosu.mosuserver.global.exception.ErrorCode;
+import life.mosu.mosuserver.infra.storage.application.FileUploadHelper;
 import life.mosu.mosuserver.infra.storage.application.S3Service;
+import life.mosu.mosuserver.infra.storage.domain.FileMoveFailLog;
+import life.mosu.mosuserver.infra.storage.domain.FileMoveFailLogRepository;
 import life.mosu.mosuserver.infra.storage.domain.Folder;
 import life.mosu.mosuserver.presentation.faq.dto.FaqCreateRequest;
 import life.mosu.mosuserver.presentation.faq.dto.FaqResponse;
+import life.mosu.mosuserver.presentation.faq.dto.FileRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.domain.Page;
@@ -27,10 +31,11 @@ import org.springframework.transaction.annotation.Transactional;
 @Service
 @RequiredArgsConstructor
 public class FaqService {
+
     private final FaqRepository faqRepository;
     private final FaqAttachmentRepository faqAttachmentRepository;
     private final S3Service s3Service;
-    private final ExecutorService executorService;
+    private final FileUploadHelper fileUploadHelper;
 
     @Value("${aws.s3.presigned-url-expiration-minutes}")
     private int durationTime;
@@ -39,7 +44,7 @@ public class FaqService {
     public void createFaq(FaqCreateRequest request) {
         FaqJpaEntity faqEntity = faqRepository.save(request.toEntity());
 
-        createAttachmentIfPresent(request, faqEntity);
+        createAttachmentIfPresent(request.attachments(), faqEntity);
     }
 
     @Transactional(readOnly = true, propagation = Propagation.SUPPORTS)
@@ -56,44 +61,32 @@ public class FaqService {
     @Transactional
     public void deleteFaq(Long faqId) {
         FaqJpaEntity faqEntity = faqRepository.findById(faqId)
-                .orElseThrow(() -> new CustomRuntimeException(ErrorCode.FILE_NOT_FOUND));
+            .orElseThrow(() -> new CustomRuntimeException(ErrorCode.FILE_NOT_FOUND));
         faqRepository.delete(faqEntity);
 
         deleteAttachmentIfPresent(faqEntity);
     }
 
 
-    private void createAttachmentIfPresent(FaqCreateRequest request, FaqJpaEntity faqEntity) {
-        if (request.file() == null || request.file().isEmpty()) {
+    private void createAttachmentIfPresent(List<FileRequest> fileRequests, FaqJpaEntity faqEntity) {
+        if (fileRequests == null) {
             return;
         }
-
         Long faqId = faqEntity.getId();
 
-        List<CompletableFuture<Void>> futures = request.file().stream()
-            .map(file -> CompletableFuture.runAsync(() -> {
-                String s3Key = s3Service.uploadFile(file, Folder.FAQ);
-                String fileName = file.getOriginalFilename();
-                faqAttachmentRepository.save(request.toAttachmentEntity(fileName, s3Key, faqId));
-            }, executorService))
-            .toList();
-
-        try{
-            CompletableFuture.allOf(futures.toArray(new CompletableFuture[0])).join();
-        }
-        catch (Exception e) {
-            throw new CustomRuntimeException(ErrorCode.FILE_UPLOAD_FAILED);
-        }
-
+        fileUploadHelper.moveToFolder(fileRequests, faqId, Folder.FAQ);
     }
 
     private FaqResponse toFaqResponse(FaqJpaEntity faq) {
-        List<FaqAttachmentJpaEntity> attachments = faqAttachmentRepository.findAllByFaqId(faq.getId());
-        List<FaqResponse.AttachmentResponse> attachmentResponses = toAttachmentResponses(attachments);
+        List<FaqAttachmentJpaEntity> attachments = faqAttachmentRepository.findAllByFaqId(
+            faq.getId());
+        List<FaqResponse.AttachmentResponse> attachmentResponses = toAttachmentResponses(
+            attachments);
         return FaqResponse.of(faq, attachmentResponses);
     }
 
-    private List<FaqResponse.AttachmentResponse> toAttachmentResponses(List<FaqAttachmentJpaEntity> attachments) {
+    private List<FaqResponse.AttachmentResponse> toAttachmentResponses(
+        List<FaqAttachmentJpaEntity> attachments) {
         return attachments.stream()
             .map(attachment -> new FaqResponse.AttachmentResponse(
                 attachment.getFileName(),
@@ -107,7 +100,8 @@ public class FaqService {
 
     //TODO: S3Service에서 SoftDelete 적용 된 파일들에 대해 따로 분리하는 로직 필요할 듯
     private void deleteAttachmentIfPresent(FaqJpaEntity entity) {
-        List<FaqAttachmentJpaEntity> attachments = faqAttachmentRepository.findAllByFaqId(entity.getId());
+        List<FaqAttachmentJpaEntity> attachments = faqAttachmentRepository.findAllByFaqId(
+            entity.getId());
         faqAttachmentRepository.deleteAll(attachments);
     }
 }

--- a/src/main/java/life/mosu/mosuserver/application/faq/FaqService.java
+++ b/src/main/java/life/mosu/mosuserver/application/faq/FaqService.java
@@ -74,7 +74,14 @@ public class FaqService {
         }
         Long faqId = faqEntity.getId();
 
-        fileUploadHelper.moveToFolder(fileRequests, faqId, Folder.FAQ);
+        for(FileRequest fileRequest : fileRequests) {
+            fileUploadHelper.updateTag(fileRequest.s3Key());
+            faqAttachmentRepository.save(fileRequest.toAttachmentEntity(
+                fileRequest.fileName(),
+                fileRequest.s3Key(),
+                faqId
+            ));
+        }
     }
 
     private FaqResponse toFaqResponse(FaqJpaEntity faq) {

--- a/src/main/java/life/mosu/mosuserver/domain/faq/FaqJpaEntity.java
+++ b/src/main/java/life/mosu/mosuserver/domain/faq/FaqJpaEntity.java
@@ -16,7 +16,7 @@ public class FaqJpaEntity extends BaseTimeEntity {
     @Column(name = "faq_id", nullable = false)
     private Long id;
 
-    @Column(name = "question", nullable = false)
+    @Column(name = "question", nullable = false, length = 500)
     private String question;
 
     @Column(name = "answer", nullable = false)

--- a/src/main/java/life/mosu/mosuserver/global/exception/ErrorCode.java
+++ b/src/main/java/life/mosu/mosuserver/global/exception/ErrorCode.java
@@ -22,6 +22,7 @@ public enum ErrorCode {
     FILE_UPLOAD_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "파일 업로드에 실패했습니다."),
     FILE_DOWNLOAD_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "파일 다운로드에 실패했습니다."),
     FILE_DELETE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "파일 삭제에 실패했습니다."),
+    WRONG_FOLDER_TYPE(HttpStatus.BAD_REQUEST, "잘못된 폴더명 입니다."),
 
     // FAQ 관련 에러
     FAQ_NOT_FOUND(HttpStatus.NOT_FOUND, "FAQ를 찾을 수 없습니다."),

--- a/src/main/java/life/mosu/mosuserver/infra/storage/application/FileUploadHelper.java
+++ b/src/main/java/life/mosu/mosuserver/infra/storage/application/FileUploadHelper.java
@@ -21,23 +21,8 @@ public class FileUploadHelper {
     private final FaqAttachmentRepository faqAttachmentRepository;
     private final ExecutorService executorService;
 
-    public void moveToFolder(List<FileRequest> fileRequests, Long faqId, Folder folder) {
-        for (FileRequest fileRequest : fileRequests) {
-
-            CompletableFuture.runAsync(() -> {
-                    s3Service.moveFile(fileRequest.s3Key(), folder);
-                }, executorService)
-                .exceptionally(ex -> {
-                    fileMoveFailLogRepository.save(
-                        FileMoveFailLog.of(faqId, fileRequest.s3Key(), folder));
-                    throw new CustomRuntimeException(ErrorCode.FILE_UPLOAD_FAILED, ex);
-                });
-
-            faqAttachmentRepository.save(fileRequest.toAttachmentEntity(
-                fileRequest.fileName(),
-                fileRequest.s3Key(),
-                faqId
-            ));
-        }
+    public void updateTag(String s3Key) {
+        s3Service.updateFileTagToActive(s3Key);
     }
+
 }

--- a/src/main/java/life/mosu/mosuserver/infra/storage/application/FileUploadHelper.java
+++ b/src/main/java/life/mosu/mosuserver/infra/storage/application/FileUploadHelper.java
@@ -1,0 +1,43 @@
+package life.mosu.mosuserver.infra.storage.application;
+
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutorService;
+import life.mosu.mosuserver.domain.faq.FaqAttachmentRepository;
+import life.mosu.mosuserver.global.exception.CustomRuntimeException;
+import life.mosu.mosuserver.global.exception.ErrorCode;
+import life.mosu.mosuserver.infra.storage.domain.FileMoveFailLog;
+import life.mosu.mosuserver.infra.storage.domain.FileMoveFailLogRepository;
+import life.mosu.mosuserver.infra.storage.domain.Folder;
+import life.mosu.mosuserver.presentation.faq.dto.FileRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class FileUploadHelper {
+    private final S3Service s3Service;
+    private final FileMoveFailLogRepository fileMoveFailLogRepository;
+    private final FaqAttachmentRepository faqAttachmentRepository;
+    private final ExecutorService executorService;
+
+    public void moveToFolder(List<FileRequest> fileRequests, Long faqId, Folder folder) {
+        for (FileRequest fileRequest : fileRequests) {
+
+            CompletableFuture.runAsync(() -> {
+                    s3Service.moveFile(fileRequest.s3Key(), folder);
+                }, executorService)
+                .exceptionally(ex -> {
+                    fileMoveFailLogRepository.save(
+                        FileMoveFailLog.of(faqId, fileRequest.s3Key(), folder));
+                    throw new CustomRuntimeException(ErrorCode.FILE_UPLOAD_FAILED, ex);
+                });
+
+            faqAttachmentRepository.save(fileRequest.toAttachmentEntity(
+                fileRequest.fileName(),
+                fileRequest.s3Key(),
+                faqId
+            ));
+        }
+    }
+}

--- a/src/main/java/life/mosu/mosuserver/infra/storage/domain/FileMoveFailLog.java
+++ b/src/main/java/life/mosu/mosuserver/infra/storage/domain/FileMoveFailLog.java
@@ -1,0 +1,36 @@
+package life.mosu.mosuserver.infra.storage.domain;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import life.mosu.mosuserver.domain.base.BaseTimeEntity;
+import lombok.Builder;
+import lombok.NoArgsConstructor;
+
+@Entity
+@NoArgsConstructor(access = lombok.AccessLevel.PROTECTED)
+public class FileMoveFailLog extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private Long faqId;
+
+    private String s3Key;
+
+    private Folder destinationFolder;
+
+    private FileMoveFailLog(Long faqId, String s3Key, Folder destinationFolder) {
+        this.s3Key = s3Key;
+        this.destinationFolder = destinationFolder;
+        this.faqId = faqId;
+    }
+
+    public static FileMoveFailLog of(Long faqId, String s3Key, Folder destinationFolder) {
+        return new FileMoveFailLog(faqId, s3Key, destinationFolder);
+    }
+
+
+}

--- a/src/main/java/life/mosu/mosuserver/infra/storage/domain/FileMoveFailLogRepository.java
+++ b/src/main/java/life/mosu/mosuserver/infra/storage/domain/FileMoveFailLogRepository.java
@@ -1,0 +1,7 @@
+package life.mosu.mosuserver.infra.storage.domain;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface FileMoveFailLogRepository extends JpaRepository<FileMoveFailLog, Long> {
+
+}

--- a/src/main/java/life/mosu/mosuserver/infra/storage/domain/Folder.java
+++ b/src/main/java/life/mosu/mosuserver/infra/storage/domain/Folder.java
@@ -11,6 +11,7 @@ public enum Folder {
     FAQ("faq", PUBLIC),
     NOTICE("notice", PUBLIC),
 
+    TEMP("temp", PRIVATE),
     INQUIRY("inquiry", PRIVATE),
     INQUIRY_ANSWER("inquiryAnswer", PRIVATE),
     ADMISSION_TICKET_IMAGE("admissionTicket/images", PRIVATE),

--- a/src/main/java/life/mosu/mosuserver/infra/storage/domain/Folder.java
+++ b/src/main/java/life/mosu/mosuserver/infra/storage/domain/Folder.java
@@ -1,5 +1,7 @@
 package life.mosu.mosuserver.infra.storage.domain;
 
+import life.mosu.mosuserver.global.exception.CustomRuntimeException;
+import life.mosu.mosuserver.global.exception.ErrorCode;
 import lombok.Getter;
 
 import static life.mosu.mosuserver.infra.storage.domain.Visibility.PRIVATE;
@@ -23,5 +25,13 @@ public enum Folder {
     Folder(String path, Visibility visibility) {
         this.path = path;
         this.visibility = visibility;
+    }
+
+    public static Folder validate(String folderName) {
+        for (Folder folder : Folder.values())
+            if (folder.name().equals(folderName)) {
+                return folder;
+            }
+        throw new CustomRuntimeException(ErrorCode.WRONG_FOLDER_TYPE);
     }
 }

--- a/src/main/java/life/mosu/mosuserver/infra/storage/presentation/S3Controller.java
+++ b/src/main/java/life/mosu/mosuserver/infra/storage/presentation/S3Controller.java
@@ -1,5 +1,8 @@
 package life.mosu.mosuserver.infra.storage.presentation;
 
+import jakarta.validation.constraints.NotNull;
+import life.mosu.mosuserver.global.exception.CustomRuntimeException;
+import life.mosu.mosuserver.global.exception.ErrorCode;
 import life.mosu.mosuserver.global.util.ApiResponseWrapper;
 import life.mosu.mosuserver.infra.storage.application.S3Service;
 import life.mosu.mosuserver.infra.storage.domain.Folder;
@@ -19,8 +22,18 @@ public class S3Controller {
     private final S3Service s3Service;
 
     @PostMapping
-    public ApiResponseWrapper<FileUploadResponse> uploadFile(@RequestParam("file") MultipartFile file) {
-        FileUploadResponse fileResponse = s3Service.uploadFile(file, Folder.TEMP);
+    public ApiResponseWrapper<FileUploadResponse> uploadFile(
+        @RequestParam("file") MultipartFile file,
+        @RequestParam(defaultValue = "temp") String folderName
+        ) {
+
+        if (file.isEmpty()) {
+            throw new CustomRuntimeException(ErrorCode.FILE_UPLOAD_FAILED, "업로드할 파일이 비어 있습니다.");
+        }
+
+        Folder folder = Folder.validate(folderName);
+
+        FileUploadResponse fileResponse = s3Service.uploadFile(file, folder);
         return ApiResponseWrapper.success(HttpStatus.CREATED, "파일 업로드 성공", fileResponse);
     }
 }

--- a/src/main/java/life/mosu/mosuserver/infra/storage/presentation/S3Controller.java
+++ b/src/main/java/life/mosu/mosuserver/infra/storage/presentation/S3Controller.java
@@ -1,0 +1,26 @@
+package life.mosu.mosuserver.infra.storage.presentation;
+
+import life.mosu.mosuserver.global.util.ApiResponseWrapper;
+import life.mosu.mosuserver.infra.storage.application.S3Service;
+import life.mosu.mosuserver.infra.storage.domain.Folder;
+import life.mosu.mosuserver.infra.storage.presentation.dto.FileUploadResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/s3")
+public class S3Controller {
+    private final S3Service s3Service;
+
+    @PostMapping
+    public ApiResponseWrapper<FileUploadResponse> uploadFile(@RequestParam("file") MultipartFile file) {
+        FileUploadResponse fileResponse = s3Service.uploadFile(file, Folder.TEMP);
+        return ApiResponseWrapper.success(HttpStatus.CREATED, "파일 업로드 성공", fileResponse);
+    }
+}

--- a/src/main/java/life/mosu/mosuserver/infra/storage/presentation/dto/FileUploadResponse.java
+++ b/src/main/java/life/mosu/mosuserver/infra/storage/presentation/dto/FileUploadResponse.java
@@ -1,0 +1,10 @@
+package life.mosu.mosuserver.infra.storage.presentation.dto;
+
+public record FileUploadResponse(
+    String fileName,
+    String s3Key
+) {
+    public static FileUploadResponse of(String fileName, String s3Key) {
+        return new FileUploadResponse(fileName, s3Key);
+    }
+}

--- a/src/main/java/life/mosu/mosuserver/presentation/faq/FaqController.java
+++ b/src/main/java/life/mosu/mosuserver/presentation/faq/FaqController.java
@@ -12,6 +12,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -24,7 +25,7 @@ public class FaqController {
 
     //TODO: 관리자 권한 체크 추가
     @PostMapping
-    public ApiResponseWrapper<Void> create(@ModelAttribute FaqCreateRequest request) {
+    public ApiResponseWrapper<Void> create(@RequestBody FaqCreateRequest request) {
         faqService.createFaq(request);
         return ApiResponseWrapper.success(HttpStatus.CREATED, "게시글 등록 성공");
     }

--- a/src/main/java/life/mosu/mosuserver/presentation/faq/dto/FaqCreateRequest.java
+++ b/src/main/java/life/mosu/mosuserver/presentation/faq/dto/FaqCreateRequest.java
@@ -2,18 +2,14 @@ package life.mosu.mosuserver.presentation.faq.dto;
 
 import jakarta.validation.constraints.NotNull;
 import java.util.List;
-import life.mosu.mosuserver.domain.faq.FaqAttachmentJpaEntity;
 import life.mosu.mosuserver.domain.faq.FaqJpaEntity;
-import life.mosu.mosuserver.infra.storage.domain.Visibility;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.multipart.MultipartFile;
 
 public record FaqCreateRequest(
 
     @NotNull String question,
     @NotNull String answer,
     Long userId,
-    @RequestParam("file") List<MultipartFile> file
+    List<FileRequest> attachments
 
 ) {
     public FaqJpaEntity toEntity() {
@@ -24,12 +20,4 @@ public record FaqCreateRequest(
             .build();
     }
 
-    public FaqAttachmentJpaEntity toAttachmentEntity(String fileName, String s3Key, Long faqId) {
-        return FaqAttachmentJpaEntity.builder()
-            .fileName(fileName)
-            .s3Key(s3Key)
-            .visibility(Visibility.PUBLIC)
-            .faqId(faqId)
-            .build();
-    }
 }

--- a/src/main/java/life/mosu/mosuserver/presentation/faq/dto/FileRequest.java
+++ b/src/main/java/life/mosu/mosuserver/presentation/faq/dto/FileRequest.java
@@ -1,0 +1,18 @@
+package life.mosu.mosuserver.presentation.faq.dto;
+
+import life.mosu.mosuserver.domain.faq.FaqAttachmentJpaEntity;
+import life.mosu.mosuserver.infra.storage.domain.Visibility;
+
+public record FileRequest(
+    String fileName,
+    String s3Key
+) {
+    public FaqAttachmentJpaEntity toAttachmentEntity(String fileName, String s3Key, Long faqId) {
+        return FaqAttachmentJpaEntity.builder()
+            .fileName(fileName)
+            .s3Key(s3Key)
+            .visibility(Visibility.PUBLIC)
+            .faqId(faqId)
+            .build();
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -25,7 +25,7 @@ spring:
     open-in-view: false
     show-sql: true
     hibernate:
-      ddl-auto: update
+      ddl-auto: create
     properties:
       hibernate:
         show_sql: true

--- a/src/test/java/life/mosu/mosuserver/FaqServiceTest.java
+++ b/src/test/java/life/mosu/mosuserver/FaqServiceTest.java
@@ -1,5 +1,6 @@
 package life.mosu.mosuserver;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.atLeastOnce;
@@ -35,36 +36,34 @@ public class FaqServiceTest {
     @Mock private FaqAttachmentRepository faqAttachmentRepository;
     @Mock private S3Service s3Service;
 
-    private ExecutorService realExecutorService;
     private FaqService faqService;
 
     @BeforeEach
     void setUp() {
-        realExecutorService = Executors.newSingleThreadExecutor();
 
         faqService = new FaqService(
                 faqRepository,
                 faqAttachmentRepository,
                 s3Service,
-                realExecutorService
+                null
         );
     }
 
     @Test
-    void FAQ_생성_요청시_FAQ_저장_그리고_파일_업로드_해야함() {
+    void 파일등록_성공() {
         // given
-        MultipartFile fileMock = mock(MultipartFile.class);
-        FaqCreateRequest request = new FaqCreateRequest("질문", "답변", 1L, List.of(fileMock));
-        FaqJpaEntity faqEntity = request.toEntity();
+        FaqCreateRequest request = mock(FaqCreateRequest.class);
+        FaqJpaEntity savedEntity = mock(FaqJpaEntity.class);
 
-        when(faqRepository.save(any())).thenReturn(faqEntity);
-        when(s3Service.uploadFile(any(), eq(Folder.FAQ))).thenReturn("s3-key");
+        when(faqRepository.save(any())).thenReturn(savedEntity);
+        when(request.toEntity()).thenReturn(savedEntity);
+        when(savedEntity.getId()).thenReturn(1L);
 
         // when
         faqService.createFaq(request);
 
-        verify(faqRepository).save(any());
-        verify(s3Service, atLeastOnce()).uploadFile(any(), eq(Folder.FAQ));
-        verify(faqAttachmentRepository, atLeastOnce()).save(any());
+        // then
+        verify(faqRepository, atLeastOnce()).save(any());
+        assertEquals(1L, savedEntity.getId());
     }
 }


### PR DESCRIPTION
## ✨ 구현한 기능
- 기존 FAQ 등록 시 파일도 함께 업로드 하는 과정을 분리하였습니다
- 파일을 미리 업로드하고 s3객체의 tag필드 + 생성 시간을 기준으로 고아 객체 관리하도록 리팩토링

## 📢 논의하고 싶은 내용
-

## 🎸 기타
- 추후 CDN을 통한 이미지 파일 등을 전달
- 추후 s3key 검증을 따로 HeadObject를 이용할까 생각 중입니다.