### PR TITLE
MOSU-55 feat: Makefile 내에 build 추가 및 mysql-exporter 추가

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,9 @@
 
 # 프로덕션 환경을 실행하는 명령어
 prod-up:
+	@echo "빌드 중..."
+	./gradlew build -x test
+	@echo "빌드 완료..."
 	@echo "프로덕션 환경을 실행 중..."
 	docker compose -f docker-compose/docker-compose.prod.yml --env-file docker-compose/.env.prod up -d --build
 	@echo "프로덕션 환경이 실행되었습니다!"
@@ -15,6 +18,9 @@ prod-down:
 # 로컬 개발 환경을 실행하는 명령어
 # docker-compose/docker-compose.local.yml 및 docker-compose/.env.local 파일이 존재해야 함
 local-up:
+	@echo "빌드 중..."
+	./gradlew build -x test
+	@echo "빌드 완료..."
 	@echo "로컬 개발 환경을 실행 중..."
 	docker compose -f docker-compose/docker-compose.local.yml --env-file docker-compose/.env.local up -d --build
 	@echo "로컬 개발 환경이 실행되었습니다!"

--- a/docker-compose/docker-compose.prod.yml
+++ b/docker-compose/docker-compose.prod.yml
@@ -68,6 +68,19 @@ services:
     networks:
       - mosu-bridge
 
+  mysqld_exporter:
+    image: prom/mysqld-exporter:latest
+    container_name: mosu-mysql-exporter
+    ports:
+      - ${DB_EXPORTER_PORT}:${DB_EXPORTER_PORT}
+    command:
+      - "--mysqld.username=${DB_USERNAME}" # 사용자 이름
+      - "--mysqld.password=${DB_PASSWORD}" # 비밀번호
+      - "--mysqld.address=${DB_HOST}:${DB_PORT}" # MySQL 서버 주소와 포트
+    depends_on:
+      - mosu-database
+    networks:
+      - mosu-bridge
   grafana:
     image: grafana/grafana:latest
     container_name: mosu-grafana

--- a/docker-compose/prometheus/config.yml
+++ b/docker-compose/prometheus/config.yml
@@ -5,16 +5,16 @@ scrape_configs:
   - job_name: 'prometheus'
     metrics_path: '/api/v1/actuator/prometheus'
     static_configs:
-      - targets: ['mosu-server:20000']
+      - targets: [ 'mosu-server:20000' ]
 
   - job_name: 'mysql'
     static_configs:
-      - targets: ['mosu-database:9104']
+      - targets: [ 'mosu-mysql-exporter:9104' ]
 
   - job_name: 'redis'
     static_configs:
-      - targets: ["mosu-redis-exporter:9121"]
+      - targets: [ "mosu-redis-exporter:9121" ]
 
   - job_name: 'prometheus-self'
     static_configs:
-      - targets: ['mosu-prometheus:9090']
+      - targets: [ 'mosu-prometheus:9090' ]


### PR DESCRIPTION
## ✨ 구현한 기능
- Makefile 내에 build 추가
- mysql-exporter 추가

## 📢 논의하고 싶은 내용
-

## 🎸 기타
-

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a MySQL exporter service to the production environment for enhanced monitoring capabilities.

* **Chores**
  * Updated the production setup process to include a build step before starting services.
  * Adjusted Prometheus configuration to monitor the new MySQL exporter service.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->