### PR TITLE
MOSU-39 feat: 신청 관련 기능 수정 및 관리자 신청 조회 관련 기능 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,4 @@ out/
 .vscode/
 
 docker-compose/.env
+docker-compose/.env.local

--- a/src/main/java/life/mosu/mosuserver/application/admin/AdminService.java
+++ b/src/main/java/life/mosu/mosuserver/application/admin/AdminService.java
@@ -1,7 +1,12 @@
 package life.mosu.mosuserver.application.admin;
 
 import java.util.List;
+import life.mosu.mosuserver.domain.admin.ApplicationQueryRepositoryImpl;
 import life.mosu.mosuserver.domain.admin.StudentQueryRepositoryImpl;
+import life.mosu.mosuserver.presentation.admin.dto.ApplicationExcelDto;
+import life.mosu.mosuserver.presentation.admin.dto.ApplicationFilter;
+import life.mosu.mosuserver.presentation.admin.dto.ApplicationListResponse;
+import life.mosu.mosuserver.presentation.admin.dto.SchoolLunchResponse;
 import life.mosu.mosuserver.presentation.admin.dto.StudentExcelDto;
 import life.mosu.mosuserver.presentation.admin.dto.StudentFilter;
 import life.mosu.mosuserver.presentation.admin.dto.StudentListResponse;
@@ -17,6 +22,7 @@ import org.springframework.stereotype.Service;
 public class AdminService {
 
     private final StudentQueryRepositoryImpl studentQueryRepository;
+    private final ApplicationQueryRepositoryImpl applicationQueryRepository;
 
     public Page<StudentListResponse> getStudents(StudentFilter filter, Pageable pageable) {
         return studentQueryRepository.searchAllStudents(filter, pageable);
@@ -25,4 +31,18 @@ public class AdminService {
     public List<StudentExcelDto> getStudentExcelData() {
         return studentQueryRepository.searchAllStudentsForExcel();
     }
+
+    public List<SchoolLunchResponse> getLunchCounts() {
+        return applicationQueryRepository.searchAllSchoolLunches();
+    }
+
+    public Page<ApplicationListResponse> getApplications(ApplicationFilter filter,
+            Pageable pageable) {
+        return applicationQueryRepository.searchAllApplications(filter, pageable);
+    }
+
+    public List<ApplicationExcelDto> getApplicationExcelData() {
+        return applicationQueryRepository.searchAllApplicationsForExcel();
+    }
+
 }

--- a/src/main/java/life/mosu/mosuserver/application/applicationschool/ApplicationSchoolService.java
+++ b/src/main/java/life/mosu/mosuserver/application/applicationschool/ApplicationSchoolService.java
@@ -1,11 +1,14 @@
 package life.mosu.mosuserver.application.applicationschool;
 
 import java.time.Duration;
+import java.util.Set;
+import java.util.stream.Collectors;
 import life.mosu.mosuserver.domain.application.AdmissionTicketImageJpaEntity;
 import life.mosu.mosuserver.domain.application.AdmissionTicketImageJpaRepository;
 import life.mosu.mosuserver.domain.application.ApplicationJpaEntity;
 import life.mosu.mosuserver.domain.application.ApplicationJpaRepository;
 import life.mosu.mosuserver.domain.application.ApplicationSchoolJpaRepository;
+import life.mosu.mosuserver.domain.application.Subject;
 import life.mosu.mosuserver.domain.applicationschool.ApplicationSchoolJpaEntity;
 import life.mosu.mosuserver.domain.profile.ProfileJpaEntity;
 import life.mosu.mosuserver.domain.profile.ProfileJpaRepository;
@@ -23,7 +26,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
-import org.springframework.web.bind.annotation.RequestParam;
 
 @Service
 @RequiredArgsConstructor
@@ -41,7 +43,6 @@ public class ApplicationSchoolService {
 
     @Transactional
     public ApplicationSchoolResponse updateSubjects(
-            @RequestParam Long userId,
             Long applicationSchoolId,
             SubjectUpdateRequest request
     ) {
@@ -56,7 +57,6 @@ public class ApplicationSchoolService {
 
     @Transactional
     public void cancelApplicationSchool(
-            @RequestParam Long userId,
             Long applicationSchoolId,
             RefundRequest request
     ) {
@@ -104,12 +104,16 @@ public class ApplicationSchoolService {
         AdmissionTicketImageJpaEntity admissionTicketImage = admissionTicketImageJpaRepository.findByApplicationId(
                 application.getId());
 
+        Set<String> subjectNames = applicationSchool.getSubjects().stream()
+                .map(Subject::getSubjectName)
+                .collect(Collectors.toSet());
+
         return AdmissionTicketResponse.of(
                 getAdmissionTicketImageUrl(admissionTicketImage),
                 profile.getUserName(),
                 profile.getBirth(),
                 applicationSchool.getExaminationNumber(),
-                applicationSchool.getSubjects(),
+                subjectNames,
                 applicationSchool.getSchoolName()
         );
 

--- a/src/main/java/life/mosu/mosuserver/domain/admin/ApplicationQueryRepository.java
+++ b/src/main/java/life/mosu/mosuserver/domain/admin/ApplicationQueryRepository.java
@@ -1,0 +1,19 @@
+package life.mosu.mosuserver.domain.admin;
+
+import java.util.List;
+import life.mosu.mosuserver.presentation.admin.dto.ApplicationExcelDto;
+import life.mosu.mosuserver.presentation.admin.dto.ApplicationFilter;
+import life.mosu.mosuserver.presentation.admin.dto.ApplicationListResponse;
+import life.mosu.mosuserver.presentation.admin.dto.SchoolLunchResponse;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+public interface ApplicationQueryRepository {
+
+    Page<ApplicationListResponse> searchAllApplications(ApplicationFilter filter,
+            Pageable pageable);
+
+    List<ApplicationExcelDto> searchAllApplicationsForExcel();
+
+    List<SchoolLunchResponse> searchAllSchoolLunches();
+}

--- a/src/main/java/life/mosu/mosuserver/domain/admin/ApplicationQueryRepositoryImpl.java
+++ b/src/main/java/life/mosu/mosuserver/domain/admin/ApplicationQueryRepositoryImpl.java
@@ -1,0 +1,260 @@
+package life.mosu.mosuserver.domain.admin;
+
+import com.querydsl.core.Tuple;
+import com.querydsl.core.types.Predicate;
+import com.querydsl.core.types.dsl.EnumPath;
+import com.querydsl.core.types.dsl.Expressions;
+import com.querydsl.jpa.impl.JPAQuery;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.time.Duration;
+import java.time.format.DateTimeFormatter;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+import life.mosu.mosuserver.domain.application.Lunch;
+import life.mosu.mosuserver.domain.application.QAdmissionTicketImageJpaEntity;
+import life.mosu.mosuserver.domain.application.QApplicationJpaEntity;
+import life.mosu.mosuserver.domain.application.Subject;
+import life.mosu.mosuserver.domain.applicationschool.QApplicationSchoolJpaEntity;
+import life.mosu.mosuserver.domain.payment.QPaymentJpaEntity;
+import life.mosu.mosuserver.domain.profile.QProfileJpaEntity;
+import life.mosu.mosuserver.domain.school.QSchoolJpaEntity;
+import life.mosu.mosuserver.domain.user.QOAuthUserJpaEntity;
+import life.mosu.mosuserver.domain.user.QUserJpaEntity;
+import life.mosu.mosuserver.infra.property.S3Properties;
+import life.mosu.mosuserver.infra.storage.application.S3Service;
+import life.mosu.mosuserver.presentation.admin.dto.ApplicationExcelDto;
+import life.mosu.mosuserver.presentation.admin.dto.ApplicationFilter;
+import life.mosu.mosuserver.presentation.admin.dto.ApplicationListResponse;
+import life.mosu.mosuserver.presentation.admin.dto.SchoolLunchResponse;
+import life.mosu.mosuserver.presentation.applicationschool.dto.AdmissionTicketResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class ApplicationQueryRepositoryImpl implements ApplicationQueryRepository {
+
+    private static final DateTimeFormatter EXCEL_DT_FORMATTER =
+            DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
+
+    private final JPAQueryFactory queryFactory;
+    private final S3Properties s3Properties;
+    private final S3Service s3Service;
+
+    private final QProfileJpaEntity profile = QProfileJpaEntity.profileJpaEntity;
+    private final QApplicationJpaEntity application = QApplicationJpaEntity.applicationJpaEntity;
+    private final QApplicationSchoolJpaEntity applicationSchool = QApplicationSchoolJpaEntity.applicationSchoolJpaEntity;
+    private final QPaymentJpaEntity payment = QPaymentJpaEntity.paymentJpaEntity;
+    private final QAdmissionTicketImageJpaEntity admissionTicketImage = QAdmissionTicketImageJpaEntity.admissionTicketImageJpaEntity;
+    private final QUserJpaEntity user = QUserJpaEntity.userJpaEntity;
+    private final QOAuthUserJpaEntity oAuthUser = QOAuthUserJpaEntity.oAuthUserJpaEntity;
+    private final QSchoolJpaEntity school = QSchoolJpaEntity.schoolJpaEntity;
+
+    @Override
+    public Page<ApplicationListResponse> searchAllApplications(ApplicationFilter filter,
+            Pageable pageable) {
+
+        JPAQuery<Tuple> query = baseQuery()
+                .where(
+                        buildNameCondition(filter.name()),
+                        buildPhoneCondition(filter.phone())
+                )
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize());
+
+        List<ApplicationListResponse> content = query.fetch().stream()
+                .map(tuple -> {
+                    Long appSchoolId = tuple.get(applicationSchool.id);
+                    Set<Subject> subjects = appSchoolId != null
+                            ? findSubjectsByApplicationSchoolId(appSchoolId)
+                            : new HashSet<>();
+                    return mapToResponse(tuple, subjects);
+                })
+                .toList();
+
+        return new PageImpl<>(content, pageable, content.size());
+    }
+
+    @Override
+    public List<ApplicationExcelDto> searchAllApplicationsForExcel() {
+        JPAQuery<Tuple> query = baseQuery();
+        return query.fetch().stream()
+                .map(tuple -> {
+                    Long appSchoolId = tuple.get(applicationSchool.id);
+                    Set<Subject> subjects = appSchoolId != null
+                            ? findSubjectsByApplicationSchoolId(appSchoolId)
+                            : new HashSet<>();
+                    return mapToExcel(tuple, subjects);
+                })
+                .toList();
+    }
+
+    @Override
+    public List<SchoolLunchResponse> searchAllSchoolLunches() {
+        return queryFactory
+                .select(
+                        school.schoolName,
+                        applicationSchool.lunch.count()
+                )
+                .from(applicationSchool)
+                .rightJoin(school).on(applicationSchool.schoolId.eq(school.id))
+                .where(applicationSchool.lunch.ne(Lunch.NONE))
+                .groupBy(school.id, school.schoolName)
+                .fetch()
+                .stream()
+                .map(t -> new SchoolLunchResponse(
+                        t.get(school.schoolName),
+                        t.get(applicationSchool.lunch.count())
+                ))
+                .toList();
+    }
+
+
+    private JPAQuery<Tuple> baseQuery() {
+        return queryFactory
+                .select(
+                        applicationSchool.id,
+                        payment.paymentKey,
+                        applicationSchool.examinationNumber,
+                        profile.userName,
+                        profile.gender,
+                        profile.birth,
+                        profile.phoneNumber,
+                        application.guardianPhoneNumber,
+                        profile.education,
+                        profile.schoolInfo.schoolName,
+                        profile.grade,
+                        applicationSchool.lunch,
+                        applicationSchool.schoolName,
+                        applicationSchool.examDate,
+                        admissionTicketImage.s3Key,
+                        admissionTicketImage.fileName,
+                        payment.paymentStatus,
+                        payment.paymentMethod,
+                        application.createdAt
+                )
+                .from(applicationSchool)
+                .leftJoin(application).on(applicationSchool.applicationId.eq(application.id))
+                .leftJoin(payment).on(payment.applicationId.eq(application.id))
+                .leftJoin(user).on(application.userId.eq(user.id))
+                .leftJoin(oAuthUser).on(application.userId.eq(user.id))
+                .leftJoin(profile).on(profile.userId.eq(user.id))
+                .leftJoin(admissionTicketImage)
+                .on(admissionTicketImage.applicationId.eq(application.id));
+    }
+
+    private Predicate buildNameCondition(String name) {
+        return (name == null || name.isBlank())
+                ? null
+                : profile.userName.contains(name);
+    }
+
+    private Predicate buildPhoneCondition(String phone) {
+        return (phone == null || phone.isBlank())
+                ? null
+                : profile.phoneNumber.contains(phone);
+    }
+
+    private Set<Subject> findSubjectsByApplicationSchoolId(Long applicationSchoolId) {
+        EnumPath<Subject> subject = Expressions.enumPath(Subject.class, "subject");
+        return new HashSet<>(
+                queryFactory
+                        .select(subject)
+                        .from(applicationSchool)
+                        .join(applicationSchool.subjects, subject)
+                        .where(applicationSchool.id.eq(applicationSchoolId))
+                        .fetch()
+        );
+    }
+
+    private ApplicationListResponse mapToResponse(Tuple tuple, Set<Subject> subjects) {
+        Set<String> subjectNames = subjects.stream()
+                .map(Subject::getSubjectName)
+                .collect(Collectors.toSet());
+
+        String lunchName = tuple.get(applicationSchool.lunch).getLunchName();
+
+        String s3Key = tuple.get(admissionTicketImage.s3Key);
+        String url = getAdmissionTicketImageUrl(s3Key);
+
+        AdmissionTicketResponse admissionTicket = AdmissionTicketResponse.of(
+                url,
+                tuple.get(profile.userName),
+                tuple.get(profile.birth),
+                tuple.get(applicationSchool.examinationNumber),
+                subjectNames,
+                tuple.get(applicationSchool.schoolName)
+        );
+
+        return new ApplicationListResponse(
+                tuple.get(payment.paymentKey),
+                tuple.get(applicationSchool.examinationNumber),
+                tuple.get(profile.userName),
+                tuple.get(profile.gender),
+                tuple.get(profile.birth),
+                tuple.get(profile.phoneNumber),
+                tuple.get(application.guardianPhoneNumber),
+                tuple.get(profile.education),
+                tuple.get(profile.schoolInfo.schoolName),
+                tuple.get(profile.grade),
+                lunchName,
+                subjectNames,
+                tuple.get(applicationSchool.schoolName),
+                tuple.get(applicationSchool.examDate),
+                tuple.get(admissionTicketImage.fileName),
+                tuple.get(payment.paymentStatus),
+                tuple.get(payment.paymentMethod),
+                tuple.get(application.createdAt),
+                admissionTicket
+        );
+    }
+
+    private ApplicationExcelDto mapToExcel(Tuple tuple, Set<Subject> subjects) {
+        Set<String> subjectNames = subjects.stream()
+                .map(Subject::getSubjectName)
+                .collect(Collectors.toSet());
+
+        String lunchName = tuple.get(applicationSchool.lunch).getLunchName();
+        String genderName = tuple.get(profile.gender).getGenderName();
+        String gradeName = tuple.get(profile.grade).getGradeName();
+        String educationName = tuple.get(profile.education).getEducationName();
+        String appliedAt = tuple.get(application.createdAt)
+                .format(EXCEL_DT_FORMATTER);
+
+        return new ApplicationExcelDto(
+                tuple.get(payment.paymentKey),
+                tuple.get(applicationSchool.examinationNumber),
+                tuple.get(profile.userName),
+                genderName,
+                tuple.get(profile.birth),
+                tuple.get(profile.phoneNumber),
+                tuple.get(application.guardianPhoneNumber),
+                educationName,
+                tuple.get(profile.schoolInfo.schoolName),
+                gradeName,
+                lunchName,
+                subjectNames,
+                tuple.get(applicationSchool.schoolName),
+                tuple.get(applicationSchool.examDate),
+                tuple.get(admissionTicketImage.fileName),
+                tuple.get(payment.paymentStatus),
+                tuple.get(payment.paymentMethod),
+                appliedAt
+        );
+    }
+
+    private String getAdmissionTicketImageUrl(String s3Key) {
+        if (s3Key == null || s3Key.isBlank()) {
+            return null;
+        }
+        return s3Service.getPreSignedUrl(
+                s3Key,
+                Duration.ofMinutes(s3Properties.getPresignedUrlExpirationMinutes())
+        );
+    }
+}

--- a/src/main/java/life/mosu/mosuserver/domain/application/ApplicationJpaEntity.java
+++ b/src/main/java/life/mosu/mosuserver/domain/application/ApplicationJpaEntity.java
@@ -1,6 +1,11 @@
 package life.mosu.mosuserver.domain.application;
 
-import jakarta.persistence.*;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
 import life.mosu.mosuserver.domain.base.BaseTimeEntity;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -21,6 +26,9 @@ public class ApplicationJpaEntity extends BaseTimeEntity {
     @Column(name = "user_id")
     private Long userId;
 
+    @Column(name = "guardian_phone_number")
+    private String guardianPhoneNumber;
+
     @Column(name = "recommender_phone_number")
     private String recommenderPhoneNumber;
 
@@ -33,13 +41,15 @@ public class ApplicationJpaEntity extends BaseTimeEntity {
 
     @Builder
     public ApplicationJpaEntity(
-        final Long userId,
-        final String recommenderPhoneNumber,
-        final boolean agreedToNotices,
-        final boolean agreedToRefundPolicy
+            final Long userId,
+            final String guardianPhoneNumber,
+            final String recommenderPhoneNumber,
+            final boolean agreedToNotices,
+            final boolean agreedToRefundPolicy
 
     ) {
         this.userId = userId;
+        this.guardianPhoneNumber = guardianPhoneNumber;
         this.recommenderPhoneNumber = recommenderPhoneNumber;
         this.agreedToNotices = agreedToNotices;
         this.agreedToRefundPolicy = agreedToRefundPolicy;

--- a/src/main/java/life/mosu/mosuserver/domain/profile/Education.java
+++ b/src/main/java/life/mosu/mosuserver/domain/profile/Education.java
@@ -1,6 +1,13 @@
 package life.mosu.mosuserver.domain.profile;
 
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
 public enum Education {
-    ENROLLED,   // 재학생
-    GRADUATED   // 졸업생
+    ENROLLED("재학생"),
+    GRADUATED("졸업생");
+
+    private final String educationName;
 }

--- a/src/main/java/life/mosu/mosuserver/domain/profile/Gender.java
+++ b/src/main/java/life/mosu/mosuserver/domain/profile/Gender.java
@@ -1,6 +1,14 @@
 package life.mosu.mosuserver.domain.profile;
 
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
 public enum Gender {
-    MALE,
-    FEMALE,
+    MALE("남자"),
+    FEMALE("여자");
+
+    private final String genderName;
+
 }

--- a/src/main/java/life/mosu/mosuserver/domain/profile/Grade.java
+++ b/src/main/java/life/mosu/mosuserver/domain/profile/Grade.java
@@ -1,7 +1,15 @@
 package life.mosu.mosuserver.domain.profile;
 
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
 public enum Grade {
-    HIGH_1,
-    HIGH_2,
-    HIGH_3;
+    HIGH_1("고등학교 1학년"),
+    HIGH_2("고등학교 2학년"),
+    HIGH_3("고등학교 3학년");
+
+    private final String gradeName;
+
 }

--- a/src/main/java/life/mosu/mosuserver/domain/school/SchoolJpaRepository.java
+++ b/src/main/java/life/mosu/mosuserver/domain/school/SchoolJpaRepository.java
@@ -1,0 +1,7 @@
+package life.mosu.mosuserver.domain.school;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface SchoolJpaRepository extends JpaRepository<SchoolJpaEntity, Long> {
+
+}

--- a/src/main/java/life/mosu/mosuserver/domain/user/UserJpaEntity.java
+++ b/src/main/java/life/mosu/mosuserver/domain/user/UserJpaEntity.java
@@ -1,6 +1,13 @@
 package life.mosu.mosuserver.domain.user;
 
-import jakarta.persistence.*;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
 import life.mosu.mosuserver.domain.base.BaseTimeEntity;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -24,15 +31,15 @@ public class UserJpaEntity extends BaseTimeEntity {
     @Column(name = "password")
     private String password;
 
-    @Column
+    @Column(name = "user_role", nullable = false, length = 50)
     @Enumerated(EnumType.STRING)
     private UserRole userRole;
 
     @Builder
     public UserJpaEntity(
-        final String loginId,
-        final String password,
-        final UserRole userRole
+            final String loginId,
+            final String password,
+            final UserRole userRole
     ) {
         this.loginId = loginId;
         this.password = password;

--- a/src/main/java/life/mosu/mosuserver/global/annotation/PhoneNumberPattern.java
+++ b/src/main/java/life/mosu/mosuserver/global/annotation/PhoneNumberPattern.java
@@ -9,15 +9,15 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 @Pattern(
-        regexp = "^010-\\d{4}-\\d{4}$",
-        message = "전화번호 형식은 010-XXXX-XXXX이어야 합니다."
+        regexp = "^01[016789]-\\d{3,4}-\\d{4}$",
+        message = "전화번호 형식은 010-XXXX-XXXX 이어야 합니다."
 )
 @Target({ElementType.FIELD, ElementType.PARAMETER})
 @Retention(RetentionPolicy.RUNTIME)
 @Constraint(validatedBy = {})
 public @interface PhoneNumberPattern {
 
-    String message() default "전화번호 형식은 010-XXXX-XXXX이어야 합니다.";
+    String message() default "전화번호 형식은 010-XXXX-XXXX 이어야 합니다.";
 
     Class<?>[] groups() default {};
 

--- a/src/main/java/life/mosu/mosuserver/global/config/ObjectMapperConfig.java
+++ b/src/main/java/life/mosu/mosuserver/global/config/ObjectMapperConfig.java
@@ -1,13 +1,19 @@
 package life.mosu.mosuserver.global.config;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration
 public class ObjectMapperConfig {
+
     @Bean
-    ObjectMapper mapper(){
-        return new ObjectMapper();
+    public ObjectMapper mapper() {
+        ObjectMapper objectMapper = new ObjectMapper();
+        objectMapper.registerModule(new JavaTimeModule());
+        objectMapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+        return objectMapper;
     }
 }

--- a/src/main/java/life/mosu/mosuserver/presentation/admin/AdminController.java
+++ b/src/main/java/life/mosu/mosuserver/presentation/admin/AdminController.java
@@ -9,6 +9,10 @@ import java.util.List;
 import life.mosu.mosuserver.application.admin.AdminService;
 import life.mosu.mosuserver.global.util.ApiResponseWrapper;
 import life.mosu.mosuserver.global.util.excel.SimpleExcelFile;
+import life.mosu.mosuserver.presentation.admin.dto.ApplicationExcelDto;
+import life.mosu.mosuserver.presentation.admin.dto.ApplicationFilter;
+import life.mosu.mosuserver.presentation.admin.dto.ApplicationListResponse;
+import life.mosu.mosuserver.presentation.admin.dto.SchoolLunchResponse;
 import life.mosu.mosuserver.presentation.admin.dto.StudentExcelDto;
 import life.mosu.mosuserver.presentation.admin.dto.StudentFilter;
 import life.mosu.mosuserver.presentation.admin.dto.StudentListResponse;
@@ -17,6 +21,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -30,6 +35,7 @@ public class AdminController {
     private final AdminService adminService;
 
     @GetMapping("/students")
+    @PreAuthorize("isAuthenticated() and hasRole('ADMIN')")
     public ResponseEntity<ApiResponseWrapper<Page<StudentListResponse>>> getStudents(
             @Valid @ModelAttribute StudentFilter filter,
             Pageable pageable
@@ -39,6 +45,7 @@ public class AdminController {
     }
 
     @GetMapping("/excel/students")
+    @PreAuthorize("isAuthenticated() and hasRole('ADMIN')")
     public void downloadStudentInfo(
             HttpServletResponse response) throws IOException {
         String fileName = URLEncoder.encode("학생정보목록.xlsx", StandardCharsets.UTF_8)
@@ -51,6 +58,41 @@ public class AdminController {
         List<StudentExcelDto> data = adminService.getStudentExcelData();
         SimpleExcelFile<StudentExcelDto> excelFile = new SimpleExcelFile<>(data,
                 StudentExcelDto.class);
+
+        excelFile.write(response.getOutputStream());
+    }
+
+    @GetMapping("/lunches")
+    @PreAuthorize("isAuthenticated() and hasRole('ADMIN')")
+    public ResponseEntity<ApiResponseWrapper<List<SchoolLunchResponse>>> getLunchCounts() {
+        List<SchoolLunchResponse> result = adminService.getLunchCounts();
+        return ResponseEntity.ok(
+                ApiResponseWrapper.success(HttpStatus.OK, "학교별 도시락 신청 수 조회 성공", result));
+    }
+
+    @GetMapping("/applications")
+    @PreAuthorize("isAuthenticated() and hasRole('ADMIN')")
+    public ResponseEntity<ApiResponseWrapper<Page<ApplicationListResponse>>> getApplications(
+            @Valid @ModelAttribute ApplicationFilter filter,
+            Pageable pageable
+    ) {
+        Page<ApplicationListResponse> result = adminService.getApplications(filter, pageable);
+        return ResponseEntity.ok(ApiResponseWrapper.success(HttpStatus.OK, "신청 목록 조회 성공", result));
+    }
+
+    @GetMapping("/excel/applications")
+    @PreAuthorize("isAuthenticated() and hasRole('ADMIN')")
+    public void downloadApplicationInfo(HttpServletResponse response) throws IOException {
+        String fileName = URLEncoder.encode("신청 목록.xlsx", StandardCharsets.UTF_8)
+                .replaceAll("\\+", "%20");
+
+        response.setContentType(
+                "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet");
+        response.setHeader("Content-Disposition", "attachment; filename*=UTF-8''" + fileName);
+
+        List<ApplicationExcelDto> data = adminService.getApplicationExcelData();
+        SimpleExcelFile<ApplicationExcelDto> excelFile = new SimpleExcelFile<>(data,
+                ApplicationExcelDto.class);
 
         excelFile.write(response.getOutputStream());
     }

--- a/src/main/java/life/mosu/mosuserver/presentation/admin/dto/ApplicationExcelDto.java
+++ b/src/main/java/life/mosu/mosuserver/presentation/admin/dto/ApplicationExcelDto.java
@@ -1,0 +1,68 @@
+package life.mosu.mosuserver.presentation.admin.dto;
+
+import java.time.LocalDate;
+import java.util.Set;
+import life.mosu.mosuserver.domain.payment.PaymentMethod;
+import life.mosu.mosuserver.domain.payment.PaymentStatus;
+import life.mosu.mosuserver.global.annotation.ExcelColumn;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor
+@Getter
+public class ApplicationExcelDto {
+
+    @ExcelColumn(headerName = "결제 번호")
+    private final String paymentNumber;
+
+    @ExcelColumn(headerName = "수험 번호")
+    private final String examinationNumber;
+
+    @ExcelColumn(headerName = "이름")
+    private final String name;
+
+    @ExcelColumn(headerName = "성별")
+    private final String gender;
+
+    @ExcelColumn(headerName = "생년월일")
+    private final LocalDate birth;
+
+    @ExcelColumn(headerName = "전화번호")
+    private final String phoneNumber;
+
+    @ExcelColumn(headerName = "보호자 전화번호")
+    private final String guardianPhoneNumber;
+
+    @ExcelColumn(headerName = "학력")
+    private final String educationLevel;
+
+    @ExcelColumn(headerName = "학교명")
+    private final String schoolName;
+
+    @ExcelColumn(headerName = "학년")
+    private final String grade;
+
+    @ExcelColumn(headerName = "도시락")
+    private final String lunch;
+
+    @ExcelColumn(headerName = "응시 과목")
+    private final Set<String> subjects;
+
+    @ExcelColumn(headerName = "시험 학교")
+    private final String examSchoolName;
+
+    @ExcelColumn(headerName = "시험 일자")
+    private final LocalDate examDate;
+
+    @ExcelColumn(headerName = "수험표 사진")
+    private final String admissionTicketImage;
+
+    @ExcelColumn(headerName = "결제 상태")
+    private final PaymentStatus paymentStatus;
+
+    @ExcelColumn(headerName = "결제 방법")
+    private final PaymentMethod paymentMethod;
+
+    @ExcelColumn(headerName = "신청 일시")
+    private final String applicationDate;
+}

--- a/src/main/java/life/mosu/mosuserver/presentation/admin/dto/ApplicationFilter.java
+++ b/src/main/java/life/mosu/mosuserver/presentation/admin/dto/ApplicationFilter.java
@@ -1,0 +1,14 @@
+package life.mosu.mosuserver.presentation.admin.dto;
+
+import life.mosu.mosuserver.global.annotation.PhoneNumberPattern;
+
+import java.time.LocalDate;
+
+public record ApplicationFilter(
+    String name,
+    @PhoneNumberPattern String phone,
+    String schoolName,
+    LocalDate applicationDate
+) {
+
+}

--- a/src/main/java/life/mosu/mosuserver/presentation/admin/dto/ApplicationListResponse.java
+++ b/src/main/java/life/mosu/mosuserver/presentation/admin/dto/ApplicationListResponse.java
@@ -1,0 +1,35 @@
+package life.mosu.mosuserver.presentation.admin.dto;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.Set;
+import life.mosu.mosuserver.domain.payment.PaymentMethod;
+import life.mosu.mosuserver.domain.payment.PaymentStatus;
+import life.mosu.mosuserver.domain.profile.Education;
+import life.mosu.mosuserver.domain.profile.Gender;
+import life.mosu.mosuserver.domain.profile.Grade;
+import life.mosu.mosuserver.presentation.applicationschool.dto.AdmissionTicketResponse;
+
+public record ApplicationListResponse(
+        String paymentNumber,
+        String examinationNumber,
+        String name,
+        Gender gender,
+        LocalDate birth,
+        String phoneNumber,
+        String guardianPhoneNumber,
+        Education educationLevel,
+        String schoolName,
+        Grade grade,
+        String lunch,
+        Set<String> subjects,
+        String examSchoolName,
+        LocalDate examDate,
+        String admissionTicketImage,
+        PaymentStatus paymentStatus,
+        PaymentMethod paymentMethod,
+        LocalDateTime applicationDate,
+        AdmissionTicketResponse admissionTicket
+) {
+
+}

--- a/src/main/java/life/mosu/mosuserver/presentation/admin/dto/SchoolLunchResponse.java
+++ b/src/main/java/life/mosu/mosuserver/presentation/admin/dto/SchoolLunchResponse.java
@@ -1,0 +1,8 @@
+package life.mosu.mosuserver.presentation.admin.dto;
+
+public record SchoolLunchResponse(
+        String schoolName,
+        Long count
+) {
+
+}

--- a/src/main/java/life/mosu/mosuserver/presentation/application/ApplicationController.java
+++ b/src/main/java/life/mosu/mosuserver/presentation/application/ApplicationController.java
@@ -1,16 +1,21 @@
 package life.mosu.mosuserver.presentation.application;
 
 import jakarta.validation.Valid;
+import java.util.List;
 import life.mosu.mosuserver.application.application.ApplicationService;
+import life.mosu.mosuserver.global.annotation.UserId;
 import life.mosu.mosuserver.global.util.ApiResponseWrapper;
 import life.mosu.mosuserver.presentation.application.dto.ApplicationRequest;
 import life.mosu.mosuserver.presentation.application.dto.ApplicationResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
-import org.springframework.web.bind.annotation.*;
-
-import java.util.List;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 
 @Slf4j
 @RestController
@@ -22,9 +27,10 @@ public class ApplicationController {
 
     //신청
     @PostMapping
+    @PreAuthorize("isAuthenticated() and hasRole('USER')")
     public ApiResponseWrapper<ApplicationResponse> apply(
-        @RequestParam Long userId,
-        @Valid @RequestBody ApplicationRequest request
+            @UserId Long userId,
+            @Valid @RequestBody ApplicationRequest request
     ) {
         ApplicationResponse response = applicationService.apply(userId, request);
         return ApiResponseWrapper.success(HttpStatus.OK, "신청 성공", response);
@@ -32,8 +38,8 @@ public class ApplicationController {
 
     //전체 신청 내역 조회
     @GetMapping
-    public ApiResponseWrapper<List<ApplicationResponse>> getAll(
-        @RequestParam Long userId
+    public ApiResponseWrapper<List<ApplicationResponse>> getApplications(
+            @UserId Long userId
     ) {
         List<ApplicationResponse> responses = applicationService.getApplications(userId);
         return ApiResponseWrapper.success(HttpStatus.OK, "신청 내역 조회 성공", responses);

--- a/src/main/java/life/mosu/mosuserver/presentation/application/dto/ApplicationRequest.java
+++ b/src/main/java/life/mosu/mosuserver/presentation/application/dto/ApplicationRequest.java
@@ -3,11 +3,13 @@ package life.mosu.mosuserver.presentation.application.dto;
 import jakarta.validation.constraints.NotNull;
 import java.util.Set;
 import life.mosu.mosuserver.domain.application.ApplicationJpaEntity;
+import life.mosu.mosuserver.global.annotation.PhoneNumberPattern;
 import life.mosu.mosuserver.global.util.FileRequest;
 
 public record ApplicationRequest(
         FileRequest admissionTicket,
-        String recommenderPhoneNumber,
+        @PhoneNumberPattern String guardianPhoneNumber,
+        @PhoneNumberPattern String recommenderPhoneNumber,
         @NotNull Set<ApplicationSchoolRequest> schools,
         @NotNull AgreementRequest agreementRequest
 ) {
@@ -15,6 +17,7 @@ public record ApplicationRequest(
     public ApplicationJpaEntity toEntity(Long userId) {
         return ApplicationJpaEntity.builder()
                 .userId(userId)
+                .guardianPhoneNumber(guardianPhoneNumber)
                 .recommenderPhoneNumber(recommenderPhoneNumber)
                 .agreedToNotices(agreementRequest().agreedToNotices())
                 .agreedToRefundPolicy(agreementRequest().agreedToRefundPolicy())

--- a/src/main/java/life/mosu/mosuserver/presentation/application/dto/ApplicationSchoolRequest.java
+++ b/src/main/java/life/mosu/mosuserver/presentation/application/dto/ApplicationSchoolRequest.java
@@ -1,45 +1,56 @@
 package life.mosu.mosuserver.presentation.application.dto;
 
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import java.time.LocalDate;
+import java.util.Set;
+import java.util.stream.Collectors;
 import life.mosu.mosuserver.domain.application.Lunch;
 import life.mosu.mosuserver.domain.application.Subject;
 import life.mosu.mosuserver.domain.applicationschool.ApplicationSchoolJpaEntity;
+import life.mosu.mosuserver.domain.school.AddressJpaVO;
 import life.mosu.mosuserver.domain.school.Area;
 import life.mosu.mosuserver.global.exception.CustomRuntimeException;
 import life.mosu.mosuserver.global.exception.ErrorCode;
 
-import java.time.LocalDate;
-import java.util.Set;
-import java.util.stream.Collectors;
-
 public record ApplicationSchoolRequest(
-    Long schoolId,
-    String schoolName,
-    String area,
-    AddressRequest address,
-    LocalDate examDate,
-    String lunch,
-    Set<String> subjects
+        @NotNull(message = "학교 ID는 필수입니다.")
+        Long schoolId,
+
+        @NotBlank(message = "학교 이름은 필수입니다.")
+        String schoolName,
+
+        String area,
+
+        @NotNull(message = "시험 날짜는 필수입니다.")
+        LocalDate examDate,
+
+        @NotBlank(message = "점심 여부는 필수입니다.")
+        String lunch,
+
+        Set<String> subjects
 ) {
 
-    public ApplicationSchoolJpaEntity toEntity(Long userId, Long applicationId) {
+    public ApplicationSchoolJpaEntity toEntity(Long userId, Long applicationId,
+            AddressJpaVO address) {
         return ApplicationSchoolJpaEntity.builder()
-            .userId(userId)
-            .applicationId(applicationId)
-            .schoolId(schoolId)
-            .schoolName(schoolName)
-            .area(validatedArea(area))
-            .address(address.toValueObject())
-            .examDate(examDate)
-            .lunch(validatedLunch(lunch))
-            .subjects(validatedSubjects(subjects))
-            .build();
+                .userId(userId)
+                .applicationId(applicationId)
+                .schoolId(schoolId)
+                .schoolName(schoolName)
+                .area(validatedArea(area))
+                .address(address)
+                .examDate(examDate)
+                .lunch(validatedLunch(lunch))
+                .subjects(validatedSubjects(subjects))
+                .build();
     }
 
     private Set<Subject> validatedSubjects(Set<String> subjects) {
         try {
             return subjects.stream()
-                .map(Subject::valueOf)
-                .collect(Collectors.toSet());
+                    .map(Subject::valueOf)
+                    .collect(Collectors.toSet());
         } catch (IllegalArgumentException e) {
             throw new CustomRuntimeException(ErrorCode.WRONG_SUBJECT_TYPE);
         }

--- a/src/main/java/life/mosu/mosuserver/presentation/application/dto/ApplicationSchoolResponse.java
+++ b/src/main/java/life/mosu/mosuserver/presentation/application/dto/ApplicationSchoolResponse.java
@@ -1,32 +1,36 @@
 package life.mosu.mosuserver.presentation.application.dto;
 
+import java.time.LocalDate;
+import java.util.Set;
+import java.util.stream.Collectors;
 import life.mosu.mosuserver.domain.application.Lunch;
 import life.mosu.mosuserver.domain.application.Subject;
 import life.mosu.mosuserver.domain.applicationschool.ApplicationSchoolJpaEntity;
 import life.mosu.mosuserver.domain.school.Area;
 
-import java.time.LocalDate;
-import java.util.Set;
-
 public record ApplicationSchoolResponse(
-    Long applicationSchoolId,
-    Area area,
-    LocalDate examDate,
-    String schoolName,
-    Lunch lunch,
-    String examinationNumber,
-    Set<Subject> subjects
+        Long applicationSchoolId,
+        Area area,
+        LocalDate examDate,
+        String schoolName,
+        Lunch lunch,
+        String examinationNumber,
+        Set<String> subjects
 ) {
 
     public static ApplicationSchoolResponse from(ApplicationSchoolJpaEntity applicationSchool) {
+        Set<String> subjectNames = applicationSchool.getSubjects().stream()
+                .map(Subject::getSubjectName)
+                .collect(Collectors.toSet());
+
         return new ApplicationSchoolResponse(
-            applicationSchool.getId(),
-            applicationSchool.getArea(),
-            applicationSchool.getExamDate(),
-            applicationSchool.getSchoolName(),
-            applicationSchool.getLunch(),
-            applicationSchool.getExaminationNumber(),
-            applicationSchool.getSubjects()
+                applicationSchool.getId(),
+                applicationSchool.getArea(),
+                applicationSchool.getExamDate(),
+                applicationSchool.getSchoolName(),
+                applicationSchool.getLunch(),
+                applicationSchool.getExaminationNumber(),
+                subjectNames
         );
     }
 

--- a/src/main/java/life/mosu/mosuserver/presentation/applicationschool/ApplicationSchoolController.java
+++ b/src/main/java/life/mosu/mosuserver/presentation/applicationschool/ApplicationSchoolController.java
@@ -1,6 +1,7 @@
 package life.mosu.mosuserver.presentation.applicationschool;
 
 import life.mosu.mosuserver.application.applicationschool.ApplicationSchoolService;
+import life.mosu.mosuserver.global.annotation.UserId;
 import life.mosu.mosuserver.global.util.ApiResponseWrapper;
 import life.mosu.mosuserver.presentation.application.dto.ApplicationSchoolResponse;
 import life.mosu.mosuserver.presentation.applicationschool.dto.AdmissionTicketResponse;
@@ -9,7 +10,13 @@ import life.mosu.mosuserver.presentation.applicationschool.dto.SubjectUpdateRequ
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 
 @Slf4j
 @RestController
@@ -21,39 +28,42 @@ public class ApplicationSchoolController {
 
     @DeleteMapping("/{applicationSchoolId}/cancel")
     public ApiResponseWrapper<Void> cancelApplicationSchool(
-        @PathVariable("applicationSchoolId") Long applicationSchoolId,
-        @RequestParam Long userId,
-        @RequestBody RefundRequest request
+            @PathVariable("applicationSchoolId") Long applicationSchoolId,
+            @UserId Long userId,
+            @RequestBody RefundRequest request
     ) {
-        applicationSchoolService.cancelApplicationSchool(userId, applicationSchoolId, request);
+        applicationSchoolService.cancelApplicationSchool(applicationSchoolId, request);
         return ApiResponseWrapper.success(HttpStatus.OK, "신청 학교 취소 및 환불 처리 완료");
     }
 
     @PutMapping("/{applicationSchoolId}/subjects")
     public ApiResponseWrapper<ApplicationSchoolResponse> updateSubjects(
-        @PathVariable("applicationSchoolId") Long applicationSchoolId,
-        @RequestParam Long userId,
-        @RequestBody SubjectUpdateRequest request
+            @PathVariable("applicationSchoolId") Long applicationSchoolId,
+            @UserId Long userId,
+            @RequestBody SubjectUpdateRequest request
     ) {
-        ApplicationSchoolResponse response = applicationSchoolService.updateSubjects(userId, applicationSchoolId, request);
+        ApplicationSchoolResponse response = applicationSchoolService.updateSubjects(
+                applicationSchoolId, request);
         return ApiResponseWrapper.success(HttpStatus.OK, "신청 과목 수정 성공", response);
     }
 
     @GetMapping("/{applicationSchoolId}")
     public ApiResponseWrapper<ApplicationSchoolResponse> getDetail(
-        @RequestParam Long userId,
-        @PathVariable("applicationSchoolId") Long applicationSchoolId
+            @UserId Long userId,
+            @PathVariable("applicationSchoolId") Long applicationSchoolId
     ) {
-        ApplicationSchoolResponse response = applicationSchoolService.getApplicationSchool(applicationSchoolId);
+        ApplicationSchoolResponse response = applicationSchoolService.getApplicationSchool(
+                applicationSchoolId);
         return ApiResponseWrapper.success(HttpStatus.OK, "신청 상세 조회 성공", response);
     }
 
     @GetMapping("/{applicationSchoolId}/admissionticket")
     public ApiResponseWrapper<AdmissionTicketResponse> getAdmissionTicket(
-        @RequestParam Long userId,
-        @PathVariable("applicationSchoolId") Long applicationSchoolId
+            @UserId Long userId,
+            @PathVariable("applicationSchoolId") Long applicationSchoolId
     ) {
-        AdmissionTicketResponse response = applicationSchoolService.getAdmissionTicket(userId, applicationSchoolId);
+        AdmissionTicketResponse response = applicationSchoolService.getAdmissionTicket(userId,
+                applicationSchoolId);
         return ApiResponseWrapper.success(HttpStatus.OK, "수험표 조회 성공", response);
     }
 }

--- a/src/main/java/life/mosu/mosuserver/presentation/applicationschool/dto/AdmissionTicketResponse.java
+++ b/src/main/java/life/mosu/mosuserver/presentation/applicationschool/dto/AdmissionTicketResponse.java
@@ -1,34 +1,34 @@
 package life.mosu.mosuserver.presentation.applicationschool.dto;
 
-import life.mosu.mosuserver.domain.application.Subject;
-
 import java.time.LocalDate;
 import java.util.Set;
 
 public record AdmissionTicketResponse(
-    String admissionTicketImageUrl,
-    String userName,
-    LocalDate birth,
-    String examinationNumber,
-    Set<Subject> subjects,
-    String schoolName
-) {
-
-    public static AdmissionTicketResponse of(
         String admissionTicketImageUrl,
         String userName,
         LocalDate birth,
         String examinationNumber,
-        Set<Subject> subjects,
+        Set<String> subjects,
         String schoolName
+) {
+
+    public static AdmissionTicketResponse of(
+            String admissionTicketImageUrl,
+            String userName,
+            LocalDate birth,
+            String examinationNumber,
+            Set<String> subjects,
+            String schoolName
     ) {
         return new AdmissionTicketResponse(
-            admissionTicketImageUrl,
-            userName,
-            birth,
-            examinationNumber,
-            subjects,
-            schoolName
+                admissionTicketImageUrl,
+                userName,
+                birth,
+                examinationNumber,
+                subjects,
+                schoolName
         );
     }
+
+
 }

--- a/src/main/java/life/mosu/mosuserver/presentation/profile/ProfileController.java
+++ b/src/main/java/life/mosu/mosuserver/presentation/profile/ProfileController.java
@@ -38,7 +38,6 @@ public class ProfileController {
 
     @PutMapping
     @PreAuthorize("isAuthenticated()")
-//    @PreAuthorize("isAuthenticated() and hasRole('USER')")
     public ApiResponseWrapper<Void> update(
             @UserId Long userId,
             @Valid @RequestBody EditProfileRequest request
@@ -49,7 +48,7 @@ public class ProfileController {
 
     @GetMapping
     public ApiResponseWrapper<ProfileDetailResponse> getProfile(
-            @RequestParam Long userId) {
+            @UserId Long userId) {
         ProfileDetailResponse response = profileService.getProfile(userId);
         return ApiResponseWrapper.success(HttpStatus.OK, "프로필 조회 성공", response);
     }

--- a/src/main/java/life/mosu/mosuserver/presentation/profile/dto/EditProfileRequest.java
+++ b/src/main/java/life/mosu/mosuserver/presentation/profile/dto/EditProfileRequest.java
@@ -2,10 +2,10 @@ package life.mosu.mosuserver.presentation.profile.dto;
 
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
-import jakarta.validation.constraints.Pattern;
 import life.mosu.mosuserver.domain.profile.Education;
 import life.mosu.mosuserver.domain.profile.Gender;
 import life.mosu.mosuserver.domain.profile.Grade;
+import life.mosu.mosuserver.global.annotation.PhoneNumberPattern;
 import life.mosu.mosuserver.global.exception.CustomRuntimeException;
 import life.mosu.mosuserver.global.exception.ErrorCode;
 
@@ -22,10 +22,7 @@ public record EditProfileRequest(
     String gender,
 
     @NotBlank(message = "휴대폰 번호는 필수입니다.")
-    @Pattern(
-        regexp = "^01[016789]\\d{7,8}$",
-        message = "휴대폰 번호 형식이 올바르지 않습니다. 예: 01012345678"
-    )
+    @PhoneNumberPattern
     String phoneNumber,
 
     String email,

--- a/src/main/java/life/mosu/mosuserver/presentation/profile/dto/ProfileRequest.java
+++ b/src/main/java/life/mosu/mosuserver/presentation/profile/dto/ProfileRequest.java
@@ -1,38 +1,36 @@
 package life.mosu.mosuserver.presentation.profile.dto;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
-import jakarta.validation.constraints.Pattern;
+import java.time.LocalDate;
 import life.mosu.mosuserver.domain.profile.Education;
 import life.mosu.mosuserver.domain.profile.Gender;
 import life.mosu.mosuserver.domain.profile.Grade;
 import life.mosu.mosuserver.domain.profile.ProfileJpaEntity;
+import life.mosu.mosuserver.global.annotation.PhoneNumberPattern;
 import life.mosu.mosuserver.global.exception.CustomRuntimeException;
 import life.mosu.mosuserver.global.exception.ErrorCode;
 
-import java.time.LocalDate;
-
 public record ProfileRequest(
-    @NotBlank(message = "이름은 필수입니다.")
-    String userName,
+        @NotBlank(message = "이름은 필수입니다.")
+        String userName,
 
-    @NotNull(message = "생년월일은 필수입니다.")
-    LocalDate birth,
+        @JsonFormat(pattern = "yyyy-MM-dd")
+        @NotNull(message = "생년월일은 필수입니다.")
+        LocalDate birth,
 
-    @NotBlank(message = "성별은 필수입니다.")
-    String gender,
+        @NotBlank(message = "성별은 필수입니다.")
+        String gender,
 
-    @NotBlank(message = "휴대폰 번호는 필수입니다.")
-    @Pattern(
-        regexp = "^01[016789]\\d{7,8}$",
-        message = "휴대폰 번호 형식이 올바르지 않습니다. 예: 01012345678"
-    )
-    String phoneNumber,
+        @NotBlank(message = "휴대폰 번호는 필수입니다.")
+        @PhoneNumberPattern
+        String phoneNumber,
 
-    String email,
-    Education education,
-    SchoolInfoRequest schoolInfo,
-    Grade grade
+        String email,
+        Education education,
+        SchoolInfoRequest schoolInfo,
+        Grade grade
 ) {
 
     public Gender validatedGender() {
@@ -45,15 +43,15 @@ public record ProfileRequest(
 
     public ProfileJpaEntity toEntity(Long userId) {
         return ProfileJpaEntity.builder()
-            .userId(userId)
-            .userName(userName)
-            .birth(birth)
-            .gender(validatedGender())
-            .phoneNumber(phoneNumber)
-            .email(email)
-            .education(education)
-            .schoolInfo(schoolInfo != null ? schoolInfo.toEntity() : null)
-            .grade(grade)
-            .build();
+                .userId(userId)
+                .userName(userName)
+                .birth(birth)
+                .gender(validatedGender())
+                .phoneNumber(phoneNumber)
+                .email(email)
+                .education(education)
+                .schoolInfo(schoolInfo != null ? schoolInfo.toEntity() : null)
+                .grade(grade)
+                .build();
     }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -41,8 +41,7 @@ spring:
   data:
     redis:
       host: ${REDIS_HOST}
-      port: ${REDIS_EXPORTER}
-      password: ${REDIS_PASSWORD}
+      port: ${VELKEY_PORT}
 
 management:
   endpoints:


### PR DESCRIPTION
## ✨ 구현한 기능
- 이전의 리뷰대로 수정 완료
- 관리자 신청 조회 기능 구현
- 관리자 신청 조회 엑셀 다운로드 기능 구현
- 관리자 학교별 도시락 수 조회 기능 구현
- profile, application 관련 @userId 적용

## 📢 논의하고 싶은 내용
- 추후 관리자 신청 조회 기능 부분에 있어 쿼리 최적화가 필요할 것 같습니다.

## 🎸 기타
-

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added admin endpoints to view and export application and school lunch data, including Excel download capability.
  * Introduced new filters and data transfer objects for enhanced application management.
  * Added support for guardian phone number in application forms.

* **Enhancements**
  * Improved phone number validation to support a wider range of formats.
  * Updated user and application endpoints to use security-based user identification instead of request parameters.
  * Provided more descriptive labels for enums such as gender, grade, and education.

* **Bug Fixes**
  * Fixed subject fields in responses to return subject names instead of objects.

* **Chores**
  * Updated `.gitignore` to exclude additional environment files.
  * Adjusted Redis configuration in application settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->